### PR TITLE
Typo on Queue feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ KubeMQ supports distributed durable FIFO based queues with the following core fe
 - **RPC and Stream Flows** - RPC flow allows an insert and pull messages in one call. Stream flow allows single message consuming in transactional way
 - **Message Policy** - Each message can be configured with expiration and delay timers. In addition, each message can specify a dead-letter queue for un-processed messages attempts
 - **Long Polling** - Consumers can wait until a message available in the queue to consume
-- **Peak Messages** - Consumers can peak into a queue without removing them from the queue
+- **Peek Messages** - Consumers can peek into a queue without removing them from the queue
 - **Ack All Queue Messages** - Any client can mark all the messages in a queue as discarded and will not be available anymore to consume
 - **Visibility timers** - Consumers can pull a message from the queue and set a timer which will cause the message not be visible to other consumers. This timer can be extended as needed.
 - **Resend Messages** - Consumers can send back a message they pulled to a new queue or send a modified message to the same queue for further processing.


### PR DESCRIPTION
Peak (to reach the highest) should be replaces with peek (to see), which is consistent with how other MQ use to describe this feature